### PR TITLE
machinekitapplication/wizard.json:  fix syntax error

### DIFF
--- a/qtcreator/wizards/machinekitapplication/wizard.json
+++ b/qtcreator/wizards/machinekitapplication/wizard.json
@@ -7,7 +7,6 @@
     "trDisplayName": "Machinekit Application",
     "trDisplayCategory": "Machinekit",
     "icon": "machinekit.png",
-    //"featuresRequired": [ "Plugin.BBIOConfig" ],
 
     "options":
     [


### PR DESCRIPTION
Comments aren't allowed in .json files.  Starting `qtcreator
-customwizard-verbose` reveals the error:

    * Failed to parse "[...]/.config/QtProject/qtcreator/templates/wizards/machinekitapplication/wizard.json":10:6: unterminated object