### PR TITLE
Change install path to $HOME/.config/QtProject

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
-QTCREATORDIR=$1/Tools/QtCreator
-TARGETDIR=$QTCREATORDIR/share/qtcreator/qbs
-SYNTAXDIR=~/.config/QtProject/qtcreator/generic-highlighter/
-WIZARDDIR=$QTCREATORDIR/share/qtcreator/templates/wizards/
+QT_BASE_DIR=$HOME/.config/QtProject
+QTCREATOR_INSTALL_DIR=$QT_BASE_DIR/qtcreator
+QBS_INSTALL_DIR=$QT_BASE_DIR/qbs
+SYNTAXDIR=$QTCREATOR_INSTALL_DIR/generic-highlighter/
+WIZARDDIR=$QTCREATOR_INSTALL_DIR/templates/wizards/
 
 cd qbs
 
-MODULEDIR=$TARGETDIR/share/qbs/modules/hal/
+MODULEDIR=$QBS_INSTALL_DIR/modules/hal/
 mkdir -p $MODULEDIR
 cp -v ./modules/hal/*.qbs $MODULEDIR
 
-IMPORTDIR=$TARGETDIR/share/qbs/imports/qbs/base/
+IMPORTDIR=$QBS_INSTALL_DIR/imports/qbs/base/
 mkdir -p $IMPORTDIR
 cp -v ./imports/*.qbs $IMPORTDIR
 cd ..
@@ -23,5 +24,6 @@ cp -v *.* $SYNTAXDIR
 cd ..
 
 cd wizards
+mkdir -p $WIZARDDIR
 cp -v -r * $WIZARDDIR
 cd ..

--- a/paths.pri
+++ b/paths.pri
@@ -1,14 +1,15 @@
 # Modify these paths to your needs and then build the project
 
-# Qt SDK directory - autodetected based on qmake path
-QTSDK_DIR=$$absolute_path($$[QT_INSTALL_PREFIX]/../..)
+# User local directory
+# https://doc-snapshots.qt.io/qbs/cli-config.html
+unix:QT_BASE_DIR=$$HOME/.config/QtProject
+win32:QT_BASE_DIR=%APPDATA%\QtProject
+macx:QT_BASE_DIR=$$HOME/Library/Preferences
 
 # Qt Creator paths for the Qt Quick Designer plugin
-# Path to the Qt Creator source - not needed anymore
-QTCREATOR_SOURCE_DIR=$$QTSDK_DIR/../qt-creator
 # Path to installed Qt Creator (where the plugin should be installed to)
-QTCREATOR_INSTALL_DIR=$$QTSDK_DIR/Tools/QtCreator
-
+QTCREATOR_INSTALL_DIR=$$QT_BASE_DIR/qtcreator
+QBS_INSTALL_DIR=$$QT_BASE_DIR/qbs
 # Qt documentation directory containing Qt documentation with .index files
 # -> somehow only the Android toolchain comes with .index files
 QT_DOC_DIR = $$[QT_INSTALL_PREFIX]/../android_armv7/doc

--- a/qbs/qbs.pro
+++ b/qbs/qbs.pro
@@ -9,9 +9,9 @@ IMPORTS_FILES = imports/MachinekitApplication.qbs
 MODULES_FILES = modules/hal/HalModule.qbs
 
 imports_install.files = $$IMPORTS_FILES
-imports_install.path = $$QTCREATOR_INSTALL_DIR/share/qtcreator/qbs/share/qbs/imports/qbs/base/
+imports_install.path = $$QBS_INSTALL_DIR/imports/qbs/base/
 
 modules_install.files = $$MODULES_FILES
-modules_install.path = $$QTCREATOR_INSTALL_DIR/share/qtcreator/qbs/share/qbs/modules/$$MODULE_NAME/
+modules_install.path = $$QBS_INSTALL_DIR/modules/$$MODULE_NAME/
 
 INSTALLS += imports_install modules_install

--- a/qtcreator/syntax/syntax.pro
+++ b/qtcreator/syntax/syntax.pro
@@ -5,7 +5,7 @@ OTHER_FILES = hal.xml
 include(../../paths.pri)
 
 files_install.files = $$OTHER_FILES
-files_install.path = $$QTCREATOR_INSTALL_DIR/share/qtcreator/generic-highlighter/
+files_install.path = $$QTCREATOR_INSTALL_DIR/generic-highlighter/
 
 INSTALLS += files_install
 

--- a/qtcreator/wizards/wizards.pro
+++ b/qtcreator/wizards/wizards.pro
@@ -9,7 +9,7 @@ WIZARD_FILES = machinekitapplication \
 include(../../paths.pri)
 
 wizard_install.files = $$WIZARD_FILES
-wizard_install.path = $$QTCREATOR_INSTALL_DIR/share/qtcreator/templates/wizards/
+wizard_install.path = $$QTCREATOR_INSTALL_DIR/templates/wizards/
 
 OTHER_FILES += $$WIZARD_FILES
 


### PR DESCRIPTION
An install local to the user may be placed in the standard Qt
configuration directory (location varies by platform).  This patch
installs files into that directory, where they are automatically found
by qtcreator and the Qt build system.

For system installs, `QT_BASE_DIR` must be adjusted to `/usr/share` on
POSIX.
